### PR TITLE
Minor fix for when barrels have ']'s inside it.

### DIFF
--- a/scripts/globals.js
+++ b/scripts/globals.js
@@ -298,7 +298,7 @@ function importObject() {
 	var firstAst = inputtext.indexOf("*");
 	var secondAst = inputtext.indexOf("*", firstAst+1);
 	var bracketOpen = inputtext.indexOf("[", secondAst);
-	var bracketClose = inputtext.indexOf("]", bracketOpen);
+	var bracketClose = inputtext.lastIndexOf("]");
 
 	// Defaults
 	document.getElementById("body").value = 32;


### PR DESCRIPTION
Current code breaks on some inputs.
example: `32*circle*#00b2e1[{"angle":0,"xoffset":0,"yoffset":0,"width":15,"baselength":60,"length":60,"basereload":120,"reload":0,"basedelay":0,"delay":0,"delayed":true,"hasKnockBack":true,"type":0,"knockback":0,"disabled":true,"spread":0,"b":[7.5,6,360],"damage":65,"comment":""}]`
